### PR TITLE
Fixed Typo in the main dashboard page

### DIFF
--- a/resources/views/pages/dashboard/index.blade.php
+++ b/resources/views/pages/dashboard/index.blade.php
@@ -57,7 +57,7 @@
                                 <li>
                                     @if($updateAvailable)
                                         <span class="text-warning">
-                                            {{ _('A new version of Shopper is available') }} - v{{ $latestVersion }}
+                                            {{ __('A new version of Shopper is available') }} - v{{ $latestVersion }}
                                         </span>
                                         <i class="fas fa-exclamation-circle text-warning"></i>
                                     @else


### PR DESCRIPTION
There was a missing _ in the the main dashboard page that resulted in undefined function

Call to undefined function _() (View: ..:\......\vendor\mckenziearts\shopper\resources\views\pages\dashboard\index.blade.php)